### PR TITLE
[FE] 새로고침 시 닉네임 모달이 반복해서 뜨는 버그 수정

### DIFF
--- a/apps/client/src/shared/lib/hooks/useRoomJoin.ts
+++ b/apps/client/src/shared/lib/hooks/useRoomJoin.ts
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { socket } from "@/shared/api/socket";
 import { emitJoinRoom } from "@/stores/socket-events";
 import { useRoomStore } from "@/stores/room";
+import { getRoomPtId } from "@/shared/lib/storage";
 
 export function useRoomJoin() {
   const { roomCode: paramCode } = useParams<{ roomCode: string }>();
@@ -48,7 +49,7 @@ export function useRoomJoin() {
   useEffect(() => {
     if (!paramCode) return;
 
-    const savedPtId = localStorage.getItem(`ptId:${paramCode}`);
+    const savedPtId = getRoomPtId(paramCode);
     // localStorage에 ptId가 없으면 신규 유저 → 모달 표시
     if (!savedPtId) {
       setIsNicknameDialogOpen(true);


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #

## 🛠️ 작업 내용 (Description)

- `useRoomJoin.ts` 내의 직접적인 `localStorage` 접근 로직을 공통 유틸리티인 `getRoomPtId`로 교체
- 구버전 키 형식(`ptId:방코드`)과 신규 표준 키 형식(`room:방코드:ptId`) 사이의 불일치로 인해 재접속 유저를 인식하지 못하던 문제 해결
- 새로고침 시 기존 입장 유저에게 닉네임 입력 모달이 다시 표시되지 않도록 개선

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

- LocalStorage 키 형식이 변경됨에 따라, 기존에 `ptId:방코드` 형식으로 저장되어 있던 데이터는 무효화될 수 있습니다. (표준 규격인 `room:방코드:ptId`로 자동 전환됨)