### PR TITLE
[FE] 에디터 6명 이상 시 경고 알림 추가 (#148)

### DIFF
--- a/apps/client/src/stores/pts.ts
+++ b/apps/client/src/stores/pts.ts
@@ -39,3 +39,12 @@ export const usePts = () => {
 export const usePt = (ptId: string | null | undefined) => {
   return usePtsStore((state) => (ptId ? state.pts[ptId] : undefined));
 };
+
+export const useCanEditCount = () => {
+  return usePtsStore(
+    (state) =>
+      Object.values(state.pts).filter(
+        (pt) => pt.role === 'editor' || pt.role === 'host',
+      ).length,
+  );
+};

--- a/apps/client/src/widgets/participants/components/Participant.tsx
+++ b/apps/client/src/widgets/participants/components/Participant.tsx
@@ -41,10 +41,12 @@ export const Participant = memo(
         return;
       }
 
+      const newRole = pt.role === 'editor' ? 'viewer' : 'editor';
+
       socket.emit(SOCKET_EVENTS.UPDATE_ROLE_PT, {
         roomCode,
         ptId: pt.ptId,
-        role: pt.role === 'editor' ? 'viewer' : 'editor',
+        role: newRole,
       });
     };
 

--- a/packages/common/src/constants/index.ts
+++ b/packages/common/src/constants/index.ts
@@ -1,31 +1,33 @@
 export const SOCKET_EVENTS = {
-  JOIN_ROOM: "room:join",
-  LEFT_ROOM: "room:left",
-  WELCOME: "room:welcome",
-  GOODBYE: "room:goodbye",
-  ROOM_PTS: "room:pts",
-  ROOM_DOC: "room:doc",
-  ROOM_AWARENESS: "room:awareness",
-  ROOM_EXPIRED: "room:expired",
-  DESTROY_ROOM: "room:destroy",
-  ROOM_DESTROYED: "room:destroyed",
+  JOIN_ROOM: 'room:join',
+  LEFT_ROOM: 'room:left',
+  WELCOME: 'room:welcome',
+  GOODBYE: 'room:goodbye',
+  ROOM_PTS: 'room:pts',
+  ROOM_DOC: 'room:doc',
+  ROOM_AWARENESS: 'room:awareness',
+  ROOM_EXPIRED: 'room:expired',
+  DESTROY_ROOM: 'room:destroy',
+  ROOM_DESTROYED: 'room:destroyed',
 
-  PT_JOINED: "room:pt_joined",
-  PT_DISCONNECT: "room:pt_disconnect",
-  PT_LEFT: "room:pt_left",
-  UPDATE_PT: "pt:update",
-  UPDATE_ROLE_PT: "pt:update_role",
-  UPDATE_NICKNAME_PT: "pt:update_nickname",
-  HOST_TRANSFERRED: "host:transferred",
+  PT_JOINED: 'room:pt_joined',
+  PT_DISCONNECT: 'room:pt_disconnect',
+  PT_LEFT: 'room:pt_left',
+  UPDATE_PT: 'pt:update',
+  UPDATE_ROLE_PT: 'pt:update_role',
+  UPDATE_NICKNAME_PT: 'pt:update_nickname',
+  HOST_TRANSFERRED: 'host:transferred',
 
-  UPDATE_FILE: "file:update",
-  UPDATE_AWARENESS: "awareness:update",
+  UPDATE_FILE: 'file:update',
+  UPDATE_AWARENESS: 'awareness:update',
 
-  CHECK_FILENAME: "file:checkname",
-  
-  RENAME_FILE: "file:rename",
-  DELETE_FILE: "file:delete",
+  CHECK_FILENAME: 'file:checkname',
 
-  REQUEST_DOC: "doc:request",
-  REQUEST_AWARENESS: "awareness:request",
+  RENAME_FILE: 'file:rename',
+  DELETE_FILE: 'file:delete',
+
+  REQUEST_DOC: 'doc:request',
+  REQUEST_AWARENESS: 'awareness:request',
 } as const;
+
+export const MAX_CAN_EDIT_COUNT = 6;


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [x] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #148

## 🛠️ 작업 내용 (Description)

호스트 포함 편집 가능 인원이 6명 이상일 때 경고 토스트를 표시하여 동시 편집으로 인한 충돌 위험을 사전에 안내합니다.

**주요 구현 사항:**
- `MAX_CAN_EDIT_COUNT` 상수 추가 (호스트 + 에디터 최대 권장 인원 = 6명)
- `useCanEditCount` 훅 추가 (호스트와 에디터를 합산하여 카운트)
- 본인이 에디터로 승격될 때:
  - 6명 이상: 성공 토스트 + 경고 설명 포함
  - 6명 미만: 간단한 성공 토스트만 표시
- 다른 참가자가 에디터로 승격될 때:
  - 호스트/에디터에게만 경고 토스트 표시
  - 뷰어에게는 표시하지 않음

**경고 메시지:**
> 현재 에디터가 N명입니다. 6명 이상 동시 편집 시 작성 내역이 소실되거나 충돌이 발생할 수 있습니다.

## 📦 패키지 변경 사항 (Dependencies)

- [ ] 없음

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- 토스트 알림 UI 스크린샷 추가 필요 -->

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [ ] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

**구현 범위:**
- 현재 구현은 개별 권한 변경 시 경고 표시만 포함
- 일괄 권한 변경, Room 전체 쓰기 모드 활성화는 향후 이슈에서 구현 예정

**기술적 결정:**
- 경고는 모달이 아닌 토스트로 구현하여 UX 침해 최소화
- 호스트와 에디터를 합산하여 카운트 (호스트도 편집 가능하므로)
- 본인 승격 시 성공 토스트에 경고를 포함, 다른 사람 승격 시 별도 경고 토스트 표시