### PR TITLE
[BE] cookie 관련 프록시 trust, same site 설정 변경

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -4,9 +4,10 @@ import { ConfigService } from '@nestjs/config';
 import { PROJECT_NAME } from '@codejam/common';
 import { ZodValidationPipe } from 'nestjs-zod';
 import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { NestExpressApplication } from '@nestjs/platform-express';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
   const configService = app.get(ConfigService);
   const port = configService.get<number>('PORT') ?? 3000;
 
@@ -15,6 +16,9 @@ async function bootstrap() {
 
   // 전역 예외 필터 등록
   app.useGlobalFilters(new HttpExceptionFilter());
+
+  // Caddy(Reverse Proxy)를 신뢰하도록 설정
+  app.set('trust proxy', 1);
 
   app.enableCors({
     origin: true,

--- a/apps/server/src/modules/room/room.controller.ts
+++ b/apps/server/src/modules/room/room.controller.ts
@@ -104,7 +104,7 @@ export class RoomController {
     res.cookie(`auth_${roomCode.toUpperCase()}`, token, {
       httpOnly: true,
       secure: isProduction,
-      sameSite: 'lax',
+      sameSite: isProduction ? 'none' : 'lax',
       maxAge: ROOM_CONFIG.COOKIE_MAX_AGE,
       path: '/',
     });


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [ ] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #

## 🛠️ 작업 내용 (Description)

- 서로 다른 도메인(Vercel ↔ NCP) 간에 쿠키를 공유하려면 sameSite: 'none'이 필수
- 따라서 isProduction일 때 secure 설정과 sameSite none으로 (none하려면 secure 필수)

- NestJS는 Caddy(Reverse Proxy) 뒤에 있어서 자신이 http로 통신한다고 착각
-  그래서 "보안 연결이 아닌데 Secure 쿠키를 구우려고 하네?" 하고 쿠키 설정을 무시할 가능성 O
- 따라서 NestJS가 Caddy가 보내주는 헤더(X-Forwarded-Proto: https)를 믿도록 설정.

## 📦 패키지 변경 사항 (Dependencies)

- [ ] 없음
- [x] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트 (Self Checklist)

- [ ] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [ ] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [ ] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

해결 기원!!
