### PR TITLE
[FE] LinearGrid flex 레이아웃 개선 및 sidebar 접힘 대응

### DIFF
--- a/apps/client/src/pages/room/LinearGrid.tsx
+++ b/apps/client/src/pages/room/LinearGrid.tsx
@@ -148,7 +148,14 @@ function LinearChild({ width, tabKey, children }: LinearChildProps) {
   };
 
   return (
-    <div style={{ width }} className="h-full" onClick={handleClick}>
+    <div
+      style={{
+        flex: `${width} 1 0%`,
+        minWidth: 0,
+      }}
+      className="h-full overflow-hidden"
+      onClick={handleClick}
+    >
       {children}
     </div>
   );


### PR DESCRIPTION
<!-- PR 제목 형식: [FE/BE/COMMON/INFRA/DOC] 제목 (#이슈번호) -->

## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: N/A

## 🛠️ 작업 내용 (Description)
사이드바가 접힐 때 에디터 영역(`LinearGrid`)이 유동적으로 확장되지 않고 고정 크기를 유지하던 레이아웃 이슈를 해결했습니다. 

### 1. 문제 원인 분석

* **고정 너비(`width`) 할당**: 기존 `LinearChild`는 JS에서 계산된 `px` 단위의 `width`를 직접 style로 주입받았습니다. 
* **반응성 부재**: 부모 Flex 컨테이너의 너비가 변해도(사이드바 접힘 등), 자식 요소가 고정 `width`를 가지고 있어 남는 공간을 채우지 못하고 붕 뜨는 현상이 발생했습니다.

### 2. 해결 방법: Flex 속성 활용 

고정 `width` 대신 `flex` 단축 속성을 사용하여 레이아웃 계산 주도권을 브라우저(CSS)에게 넘겼습니다.
* **`flex-basis: 0%`**: "내 기본 크기는 0이다. 내가 가진 콘텐츠 크기에 연연하지 않고 오직 부모가 정해준 공간 안에서 움직이겠다"는 선언입니다.
* **`flex-grow: ${width}`**: 기존에 계산되어 넘어오던 `width` 값을 절대값이 아닌 **상대적 비율**로 활용합니다. 탭이 하나라면 전체를 먹고, 여러 개라면 비율대로 나눠 가집니다. 
* **`min-width: 0`**: Flex 아이템이 내부 콘텐츠 크기 때문에 줄어들지 못하는 기본 동작을 방지하여, 사이드바 변화에 즉각 반응하게 합니다. 

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

**before**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4dc7e5c9-ec43-4dec-af50-bebfd0357f40" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f9ff790c-a3e4-4ce7-aef8-3d96ab9a79c9" />


> 에디터와 output 사이의 공간 발생 (너비 재계산 X)


<br/>

**after**
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/af6ed90e-7a7b-44d9-b352-e35a920611fb" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4cc21a0b-dd69-489f-bdf0-bb716e8bd025" />



## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [x] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

