### PR TITLE
[INFRA] Piston 배포 workflow 수정

### DIFF
--- a/apps/piston/deploy.md
+++ b/apps/piston/deploy.md
@@ -6,7 +6,7 @@ Minimal Piston environment for testing, CI/CD, or isolated deployment.
 
 ```bash
 # Start Piston
-docker compose -f docker-compose.piston.yml up -d --build
+docker compose -f docker-compose.piston.yml up -d
 
 # Watch setup
 docker compose -f docker-compose.piston.yml logs -f piston-setup
@@ -28,7 +28,7 @@ curl http://localhost:2000/api/v2/runtimes
 ### 1. Start
 
 ```bash
-docker compose -f docker-compose.piston.yml up -d --build
+docker compose -f docker-compose.piston.yml up -d
 ```
 
 ### 2. Monitor
@@ -69,7 +69,7 @@ docker compose -f docker-compose.piston.yml logs piston-setup | grep "already in
 ## Custom Port
 
 ```bash
-PISTON_PORT=3000 docker compose -f docker-compose.piston.yml up -d --build
+PISTON_PORT=3000 docker compose -f docker-compose.piston.yml up -d
 curl http://localhost:3000/api/v2/runtimes
 ```
 

--- a/docker-compose.piston.yml
+++ b/docker-compose.piston.yml
@@ -16,8 +16,7 @@ services:
   # Polls until Piston API is ready, then installs language runtimes
   # Skip installation if the runtime is already installed
   piston-setup:
-    build:
-      context: ./apps/piston
+    image: piston-setup:latest
     container_name: piston-setup
     depends_on:
       - piston


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Infrastructure** (DevOps, CI/CD, Docker)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #192 

## 🛠️ 작업 내용 (Description)

- NCP Registry 로 Piston 이미지를 보내도록 수정
  - NCP 서버에서 빌드하지 않도록 수정
- .env.staging, .env.prod 의 PISTON_API_URL 수정
  - Docker 브리지 네트워크 게이트웨이 주소 사용

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?

## 💬 추가 논의사항 (Optional)

NestJs <-> Piston 컨테이너 간 네트워크 연결을 위해 Docker 브리지 네트워크 게이트웨이 주소를 사용했습니다.

codejam-network 같은 사용자 정의 네트워크를 사용하는 것이 더 나은 방법인 것 같은데,
지금은 통신이 되는지 확인한 다음 나중에 더 찾아보려 합니다.
