### PR TITLE
[FE] 닉네임/비밀번호 입력 모달 외부 클릭 닫힘 방지

### DIFF
--- a/apps/client/src/widgets/nickname-input/NicknameInputDialog.tsx
+++ b/apps/client/src/widgets/nickname-input/NicknameInputDialog.tsx
@@ -56,7 +56,11 @@ export function NicknameInputDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent
+        showCloseButton={false}
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>닉네임 입력</DialogTitle>

--- a/apps/client/src/widgets/password-input/PasswordInputDialog.tsx
+++ b/apps/client/src/widgets/password-input/PasswordInputDialog.tsx
@@ -58,7 +58,11 @@ export function PasswordDialogProps({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent showCloseButton={false}>
+      <DialogContent
+        showCloseButton={false}
+        onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
         <form onSubmit={handleSubmit}>
           <DialogHeader>
             <DialogTitle>비밀번호 입력</DialogTitle>


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #

## 🛠️ 작업 내용 (Description)

- 닉네임 입력 모달과 비밀번호 입력 모달에서 외부 영역 클릭 시 모달이 닫히는 문제 수정
- ESC 키로 모달이 닫히는 동작도 함께 방지
- `onInteractOutside`, `onEscapeKeyDown` 이벤트 핸들러 추가로 필수 입력 완료 전 닫힘 방지

### 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `widgets/nickname-input/NicknameInputDialog.tsx` | 외부 클릭/ESC 닫힘 방지 |
| `widgets/password-input/PasswordInputDialog.tsx` | 외부 클릭/ESC 닫힘 방지 |

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

| Before | After |
|--------|-------|
| 모달 외부 클릭 시 입력 없이도 닫힘 | 모달 외부 클릭해도 닫히지 않음 |

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [ ] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

- Radix UI Dialog의 기본 동작(overlay 클릭 시 닫힘)을 `preventDefault()`로 방지
- 필수 입력 다이얼로그이므로 사용자가 반드시 입력을 완료해야만 닫히도록 변경