### PR TITLE
[FE] 클라이언트 리렌더링 최적화

### DIFF
--- a/apps/client/src/shared/lib/hooks/useFileRename.ts
+++ b/apps/client/src/shared/lib/hooks/useFileRename.ts
@@ -10,16 +10,16 @@ import { extname } from '../file';
 
 export function useFileRename(roomCode: string | null) {
   const [isDuplicated, setIsDuplicated] = useState(false);
-  const {
-    getFileId,
-    createFile,
-    setActiveFile,
-    activeFileId,
-    measureCapacity,
-    addTempFile,
-    clearTempFile,
-    getTempFiles,
-  } = useFileStore();
+
+  const activeFileId = useFileStore((state) => state.activeFileId);
+
+  const getFileId = useFileStore((state) => state.getFileId);
+  const createFile = useFileStore((state) => state.createFile);
+  const setActiveFile = useFileStore((state) => state.setActiveFile);
+  const measureCapacity = useFileStore((state) => state.measureCapacity);
+  const addTempFile = useFileStore((state) => state.addTempFile);
+  const clearTempFile = useFileStore((state) => state.clearTempFile);
+  const getTempFiles = useFileStore((state) => state.getTempFiles);
 
   if (!roomCode) {
     throw new Error('Invalid roomCode');


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #N/A

## 🛠️ 작업 내용 (Description)

- 클라이언트 리렌더링 최적화

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음

## 📸 스크린샷

### Before

<img width="1002" height="837" alt="image" src="https://github.com/user-attachments/assets/5b14d0f3-eccb-4e6a-bbf1-c8b4475141fb" />

### After

<img width="1003" height="833" alt="image" src="https://github.com/user-attachments/assets/9672505d-e960-481d-8a24-a7a6f37a3841" />


## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?

## 💬 설명

### 설명

- CodeMirror 에서 글자를 입력하면 File Store 의 onYDocUpdate 가 실행됨
- onYDocUpdate 가 실행되면 measureCapacity 가 실행됨
- measureCapacity 가 실행되면 set 함수에 의해 File Store 의 state 가 변화함
- useFileRename 은 File Store 전체를 구독 중이므로 File Store 의 state 가 변화하면 useFileRename 이 다시 실행됨
- useFileRename 은 RoomPage 내에서 호출되고 있으므로, useFileRename 으로 인해 RoomPage 가 리렌더링됨
- RoomPage 가 리렌더링되면 Child 가 모두 리렌더링됨
- Sidebar 와 Viewer 가 모두 리렌더링되면서 매우 큰 오버헤드가 생김
- Selector 를 사용해서 구독하면, useFileRename 이 더 이상 capacity 등의 상태를 참조하지 않게 됨
- RoomPage 가 더 이상 재렌더링되지 않음

※ useSettings Hook 또한 리렌더링 문제를 일으킬 가능성이 있음

### TODO

- File Store 가 너무 많은 일을 하고 있음
- Store 는 일반적으로 state 와 action 으로 구성됨
- 현재 File Store 의 많은 함수들은 Y.Doc 을 조작하고 있는데, 이들은 Y.Doc 의 참조를 아무것도 변화시키지 않음
- state 를 변화시키지 않는 함수들은 File Store 에 존재할 이유가 없는 함수들임
- 이들을 별도 모듈로 분리하고 Y.Doc update 시 해당 모듈이 File Store 의 action 을 호출해서 state 를 바꾸도록 하는 것이 좋아 보임
- 그리고 useFileRename 도 RoomPage 가 아닌 가능하면 다른 곳으로 옮기는 것이 나아 보임
