### PR TITLE
[FE/BE] WebSocket 연결 설정 개선

### DIFF
--- a/apps/client/src/shared/api/socket.ts
+++ b/apps/client/src/shared/api/socket.ts
@@ -5,5 +5,5 @@ const SOCKET_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 export const socket = io(SOCKET_URL, {
   autoConnect: false,
   withCredentials: true,
-  transports: ['websocket', 'polling'],
+  transports: ['polling', 'websocket'],
 });

--- a/apps/server/src/modules/collaboration/collaboration.gateway.ts
+++ b/apps/server/src/modules/collaboration/collaboration.gateway.ts
@@ -38,7 +38,8 @@ import { WsExceptionFilter } from '../../common/filters/ws-exception.filter';
 @UseFilters(new WsExceptionFilter())
 @WebSocketGateway({
   cors: {
-    origin: '*', // 개발용: 모든 출처 허용 (배포 시 프론트 주소로 변경)
+    origin: true,
+    credentials: true,
   },
 })
 export class CollaborationGateway


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [x] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: N/A

## 🛠️ 작업 내용 (Description)

- 클라이언트 WebSocket transports 순서 변경 (polling -> websocket)
- 서버 CORS 설정에 credentials 옵션 추가
- CORS origin을 동적으로 허용하도록 변경

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [x] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

쿠키 문제 해결을 위한 두번째 단계입니다.

Vercel Rewrites는 HTTP 요청 프록시는 잘 지원하지만, wss 프로토콜의 지속적인 연결은 완벽하게 프록시하지 못할 수 있습니다. 보통 Vercel의 인프라(Serverless/Edge) 특성상 Upgrade: websocket 헤더를 처리하는 과정에서 연결이 끊기는 경우가 빈번하다고 합니다. 

따라서 먼저 polling을 시도한 후에, websocket으로 업그레이드되게 합니다.


