### PR TITLE
[FE] 헤더 타이틀 UI 디자인 개선

### DIFF
--- a/apps/client/src/widgets/header/ui/Header.tsx
+++ b/apps/client/src/widgets/header/ui/Header.tsx
@@ -14,17 +14,19 @@ export default function Header({ roomCode }: HeaderProps) {
   const { role } = usePermission();
 
   return (
-    <header className="flex items-center justify-between gap-1 py-1">
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <Title />
-      </div>
-      <div className="flex shrink-0 items-center gap-1">
-        <RoleBadge role={role} />
-        <RoomCode roomCode={roomCode} />
-        {/* <CodeExecutionButton /> */}
-        <ShareButton roomCode={roomCode} />
-        <DestroyRoomButton />
-        <ThemeToggleButton />
+    <header className="border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between gap-1 py-1">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <Title />
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <RoleBadge role={role} />
+          <RoomCode roomCode={roomCode} />
+          {/* <CodeExecutionButton /> */}
+          <ShareButton roomCode={roomCode} />
+          <DestroyRoomButton />
+          <ThemeToggleButton />
+        </div>
       </div>
     </header>
   );

--- a/apps/client/src/widgets/header/ui/components/Title.tsx
+++ b/apps/client/src/widgets/header/ui/components/Title.tsx
@@ -1,6 +1,5 @@
 import { useState, type ChangeEvent, type KeyboardEvent } from 'react';
 import { Pencil } from 'lucide-react';
-import { Button } from '@codejam/ui';
 import { useFileStore } from '@/stores/file';
 import { usePermission } from '@/shared/lib/hooks/usePermission';
 import { PERMISSION } from '@codejam/common';
@@ -8,31 +7,19 @@ import { PERMISSION } from '@codejam/common';
 export function Title() {
   const docMeta = useFileStore((state) => state.docMeta);
   const fileManager = useFileStore((state) => state.fileManager);
-
   const { can } = usePermission();
   const canEdit = can(PERMISSION.EDIT_DOCS);
 
   const [editTitle, setEditTitle] = useState('');
   const [isEditable, setIsEditable] = useState(false);
 
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setEditTitle(e.target.value);
-  };
-
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.code === 'Enter') {
-      handleSubmit();
-    }
-    if (e.code === 'Escape') {
-      setIsEditable(false);
-      setEditTitle(docMeta?.title ?? '');
-    }
-  };
+  const textStyles =
+    'font-sans text-lg font-bold tracking-tight text-foreground leading-none';
+  const underlineStyles =
+    'border-b-2 border-border group-hover:border-muted-foreground transition-colors';
 
   const handleSubmit = () => {
     if (!fileManager) return;
-
-    // Update Y.Doc
     const newTitle = editTitle.trim() || docMeta?.title || '';
     fileManager.setTitle(newTitle);
     setIsEditable(false);
@@ -46,44 +33,45 @@ export function Title() {
 
   if (canEdit && isEditable) {
     return (
-      <input
-        type="text"
-        className="outline-input focus:outline-ring mx-1 field-sizing-content max-w-full min-w-0 bg-transparent px-1 text-xl font-bold outline"
-        maxLength={100}
-        value={editTitle}
-        onChange={handleChange}
-        onKeyDown={handleKeyDown}
-        onBlur={handleSubmit}
-        autoFocus
-      />
+      <div className="flex h-10 min-w-0 flex-1 items-center px-4">
+        <div className="group flex max-w-full items-center gap-2">
+          <input
+            type="text"
+            className={`${textStyles} ${underlineStyles} focus:border-muted-foreground [field-sizing:content] max-w-full min-w-[60px] bg-transparent pb-1 outline-none`}
+            value={editTitle}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setEditTitle(e.target.value)
+            }
+            onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+              if (e.code === 'Enter') handleSubmit();
+              if (e.code === 'Escape') {
+                setIsEditable(false);
+                setEditTitle(docMeta?.title ?? '');
+              }
+            }}
+            onBlur={handleSubmit}
+            autoFocus
+          />
+          <Pencil className="text-muted-foreground size-4 shrink-0" />
+        </div>
+      </div>
     );
   }
 
   return (
-    <div className="group flex min-w-0 items-center gap-2 px-2">
-      <h1 className="truncate text-xl font-bold">{docMeta?.title || ''}</h1>
-      {canEdit && <EditButton onClick={handleEditClick} />}
+    <div className="flex h-10 min-w-0 flex-1 items-center px-4">
+      <div
+        onClick={handleEditClick}
+        className="group hover:bg-muted/30 -ml-2 inline-flex max-w-full cursor-pointer items-center gap-2 rounded-md px-2 transition-colors"
+      >
+        <h1 className={`${textStyles} ${underlineStyles} truncate pb-1`}>
+          {docMeta?.title || '제목 없음'}
+        </h1>
+
+        {canEdit && (
+          <Pencil className="text-muted-foreground size-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+        )}
+      </div>
     </div>
-  );
-}
-
-/**
- * Edit Button
- */
-
-interface EditButtonProps {
-  onClick: () => void;
-}
-
-function EditButton({ onClick }: EditButtonProps) {
-  return (
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-6 w-6 opacity-0 transition-opacity group-hover:opacity-100"
-      onClick={onClick}
-    >
-      <Pencil className="h-4 w-4" />
-    </Button>
   );
 }


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: N/A

## 🛠️ 작업 내용 (Description)

- 타이틀 편집 시 밑줄 스타일로 변경 (기존 아웃라인 제거)
- 호버 시 배경색 추가로 클릭 가능 영역 시각화
- 헤더 하단에 border 추가하여 구분선 표시
- 편집 아이콘 항상 표시하도록 변경 (편집 모드일 때)
- 타이틀 영역 높이 고정 (h-10) 및 패딩 조정
- field-sizing:content 속성으로 입력 필드 너비 자동 조정
- 불필요한 EditButton 컴포넌트 제거하고 인라인으로 변경
- 텍스트 스타일 일관성 개선 (font-bold, tracking-tight)

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

<img width="687" height="458" alt="스크린샷 2026-02-05 000311" src="https://github.com/user-attachments/assets/abde203d-009e-4514-b61c-351ba5745595" />
<img width="637" height="305" alt="스크린샷 2026-02-05 000338" src="https://github.com/user-attachments/assets/3b121ece-9866-4a08-9641-b40c948e9fb5" />
<img width="447" height="231" alt="image" src="https://github.com/user-attachments/assets/cbbfef2a-f806-47d7-9e10-ff4e51f12620" />


## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [x] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

<!-- 리뷰 시 특별히 확인해야 할 부분이나 논의가 필요한 부분 -->
