### PR TITLE
[BE] 부하테스트를 위한 Throttling 제한 우회 기능 구현

### DIFF
--- a/apps/server/src/config/env.validation.ts
+++ b/apps/server/src/config/env.validation.ts
@@ -30,4 +30,15 @@ export const validationSchema = Joi.object({
   NODE_ENV: Joi.string()
     .valid('development', 'production', 'test')
     .default('development'),
+
+  // =======================================================
+  // Throttling (부하테스트 시 환경변수로 제한 우회 가능)
+  // 운영 서버에서는 설정하지 않으면 기본값 적용
+  // =======================================================
+  // 방 생성 API: 1분당 N회 (기본값 2)
+  ROOM_CREATE_THROTTLE_LIMIT: Joi.number().default(2),
+  // 코드 실행 API: 1분당 N회 (기본값 6)
+  EXECUTE_CODE_THROTTLE_LIMIT: Joi.number().default(6),
+  // 채팅 메시지: 1초당 N회 (기본값 10)
+  CHAT_MESSAGE_THROTTLE_LIMIT: Joi.number().default(10),
 });

--- a/apps/server/src/modules/room/room.controller.ts
+++ b/apps/server/src/modules/room/room.controller.ts
@@ -23,6 +23,16 @@ import { CommonThrottlerGuard } from '../../common/guards/common-throttler.guard
 import { Throttle } from '@nestjs/throttler';
 import { type Response } from 'express';
 
+/**
+ * 방 생성 Throttle Limit (환경변수로 조절 가능)
+ * - 운영 서버: 기본값 2 (1분당 2회)
+ * - 스테이징/테스트: .env에서 ROOM_CREATE_THROTTLE_LIMIT=1000 등으로 상향
+ */
+const ROOM_CREATE_LIMIT = parseInt(
+  process.env.ROOM_CREATE_THROTTLE_LIMIT || '2',
+  10,
+);
+
 @Controller()
 export class RoomController {
   constructor(
@@ -45,14 +55,14 @@ export class RoomController {
 
   @Post(API_ENDPOINTS.ROOM.CREATE_QUICK)
   @UseGuards(CommonThrottlerGuard)
-  @Throttle({ default: { limit: 2, ttl: 60000 } })
+  @Throttle({ default: { limit: ROOM_CREATE_LIMIT, ttl: 60000 } })
   async createQuickRoom(): Promise<CreateQuickRoomResponseDto> {
     return await this.roomService.createQuickRoom();
   }
 
   @Post(API_ENDPOINTS.ROOM.CREATE_CUSTOM)
   @UseGuards(CommonThrottlerGuard)
-  @Throttle({ default: { limit: 2, ttl: 60000 } })
+  @Throttle({ default: { limit: ROOM_CREATE_LIMIT, ttl: 60000 } })
   async createCustomRoom(
     @Body() dto: CreateCustomRoomRequestDto,
     @Res({ passthrough: true }) res: Response,


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [ ] **Frontend** (React)
- [x] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #

## 🛠️ 작업 내용 (Description)

부하테스트 시 동일 IP에서 발생하는 다수의 요청(방 생성, 코드 실행, 채팅 등)이 서버의 Rate Limiting에 의해 차단되는 문제를 해결하기 위해, Throttling 제한 수치를 환경변수로 조절할 수 있도록 개선하였습니다.

- **환경변수 검증 로직 추가**: `env.validation.ts`에 Throttling 관련 변수 3종 추가 (기본값은 기존과 동일하게 유지하여 운영 안정성 확보)
- **방 생성 API 개선**: `RoomController`의 방 생성 제한 수치를 환경변수(`ROOM_CREATE_THROTTLE_LIMIT`)로 관리
- **소켓 이벤트 개선**: `CollaborationGateway`의 코드 실행(`EXECUTE_CODE_THROTTLE_LIMIT`) 및 채팅(`CHAT_MESSAGE_THROTTLE_LIMIT`) 제한 수치를 환경변수로 관리
- **멀티룸 테스트 스크립트 수정**: 실제 API 엔드포인트(`POST /api/rooms/quick`)에 맞게 방 생성 로직 수정 및 Rate Limit 회피를 위한 재시도 로직 추가

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [x] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

- 현재 `@Throttle` 데코레이터의 특성상 `ConfigService` 주입이 불가능하여 `process.env`를 직접 참조하고 있습니다. 이는 NestJS Throttler의 일반적인 제약사항이며, 환경변수 검증은 `env.validation.ts`에서 Joi를 통해 철저히 수행하고 있습니다.