### PR TITLE
[FE] FileObserver 컴포넌트를 통해 activeFileId 가 변경될 시 탭이 자동으로 생성

### DIFF
--- a/apps/client/src/pages/room/FileObserver.tsx
+++ b/apps/client/src/pages/room/FileObserver.tsx
@@ -1,0 +1,21 @@
+import { LinearTabApiContext } from '@/contexts/ProviderAPI';
+import { ActiveTabContext } from '@/contexts/TabProvider';
+import { useFileStore } from '@/stores/file';
+import { useContext, useEffect } from 'react';
+
+export default function FileObserver() {
+  const { appendLinear } = useContext(LinearTabApiContext);
+  const { activeTab } = useContext(ActiveTabContext);
+  const activeFileId = useFileStore((state) => state.activeFileId);
+  const getFileName = useFileStore((state) => state.getFileName);
+
+  useEffect(() => {
+    if (activeFileId && activeTab.active) {
+      appendLinear(activeTab.active, activeFileId, {
+        fileName: getFileName(activeFileId),
+      });
+    }
+  }, [activeFileId]);
+
+  return <></>;
+}

--- a/apps/client/src/pages/room/RoomPage.tsx
+++ b/apps/client/src/pages/room/RoomPage.tsx
@@ -23,6 +23,7 @@ import { TabProvider } from '@/contexts/TabProvider';
 import TabViewer from './TabViewer';
 import { TabLayout } from './TabLayout';
 import { GlobalShortcutHandler, ShortcutHUD } from '@/widgets/global-shortcuts';
+import FileObserver from './FileObserver';
 
 function RoomPage() {
   const {
@@ -84,6 +85,7 @@ function RoomPage() {
     >
       <TabProvider>
         <ProviderAPI>
+          <FileObserver />
           <RoomSidebar />
           <div className="flex min-w-0 flex-1 flex-col">
             <Header roomCode={paramCode!} />

--- a/apps/client/src/shared/lib/hooks/useFileRename.ts
+++ b/apps/client/src/shared/lib/hooks/useFileRename.ts
@@ -1,10 +1,8 @@
 import { useFileStore } from '@/stores/file';
 import { EXT_TYPES } from '@codejam/common';
-import { useContext, useState } from 'react';
+import { useState } from 'react';
 import { toast } from '@codejam/ui';
 import { extname } from '../file';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
-import { ActiveTabContext } from '@/contexts/TabProvider';
 
 export function useFileRename(roomCode: string | null) {
   const [isDuplicated, setIsDuplicated] = useState(false);
@@ -12,15 +10,12 @@ export function useFileRename(roomCode: string | null) {
   const activeFileId = useFileStore((state) => state.activeFileId);
 
   const getFileId = useFileStore((state) => state.getFileId);
-  const getFileName = useFileStore((state) => state.getFileName);
   const createFile = useFileStore((state) => state.createFile);
   const setActiveFile = useFileStore((state) => state.setActiveFile);
   const measureCapacity = useFileStore((state) => state.measureCapacity);
   const addTempFile = useFileStore((state) => state.addTempFile);
   const clearTempFile = useFileStore((state) => state.clearTempFile);
   const getTempFiles = useFileStore((state) => state.getTempFiles);
-  const { appendLinear } = useContext(LinearTabApiContext);
-  const { activeTab } = useContext(ActiveTabContext);
 
   if (!roomCode) {
     throw new Error('Invalid roomCode');
@@ -95,9 +90,6 @@ export function useFileRename(roomCode: string | null) {
         if (result) {
           const content = await file.text();
           const fileId = createFile(file.name, content);
-          appendLinear(activeTab.active, fileId, {
-            fileName: getFileName(fileId),
-          });
           if (!activeFileId) {
             setActiveFile(fileId);
           }

--- a/apps/client/src/widgets/chat/components/FileMention.tsx
+++ b/apps/client/src/widgets/chat/components/FileMention.tsx
@@ -1,8 +1,5 @@
-import { useContext } from 'react';
 import { FileText } from 'lucide-react';
 import { useFileStore } from '@/stores/file';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
-import { ActiveTabContext } from '@/contexts/TabProvider';
 
 type FileMentionProps = {
   fileName: string;
@@ -17,9 +14,6 @@ type FileMentionProps = {
 export function FileMention({ fileName }: FileMentionProps) {
   const getFileId = useFileStore((state) => state.getFileId);
   const setActiveFile = useFileStore((state) => state.setActiveFile);
-  const getFileName = useFileStore((state) => state.getFileName);
-  const { activeTab } = useContext(ActiveTabContext);
-  const { appendLinear } = useContext(LinearTabApiContext);
 
   // 렌더링 시점에 파일 존재 여부 확인
   const fileId = getFileId(fileName);
@@ -29,9 +23,6 @@ export function FileMention({ fileName }: FileMentionProps) {
     if (isDeleted) return;
 
     setActiveFile(fileId);
-    appendLinear(activeTab.active, fileId, {
-      fileName: getFileName(fileId),
-    });
   };
 
   // 삭제된 파일

--- a/apps/client/src/widgets/files/components/File.tsx
+++ b/apps/client/src/widgets/files/components/File.tsx
@@ -1,17 +1,9 @@
 import { cn } from '@codejam/ui';
 import { useFileStore } from '@/stores/file';
-import {
-  memo,
-  useContext,
-  useState,
-  type DragEvent,
-  type MouseEvent,
-} from 'react';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
+import { memo, useState, type DragEvent, type MouseEvent } from 'react';
 import { RenameDialog } from '@/widgets/dialog/RenameDialog';
 import { DeleteDialog } from '@/widgets/dialog/DeleteDialog';
 import { FileMoreMenu } from './FileMoreMenu';
-import { ActiveTabContext } from '@/contexts/TabProvider';
 
 type DialogType = 'RENAME' | 'DELETE' | undefined;
 type FileProps = {
@@ -27,9 +19,6 @@ const INACTIVE_FILE_HOVER =
 export const File = memo(({ fileId, fileName, hasPermission }: FileProps) => {
   const setActiveFile = useFileStore((state) => state.setActiveFile);
   const activeFileId = useFileStore((state) => state.activeFileId);
-  const getFileName = useFileStore((state) => state.getFileName);
-  const { appendLinear } = useContext(LinearTabApiContext);
-  const { activeTab } = useContext(ActiveTabContext);
 
   const [x, setX] = useState(0);
   const [y, setY] = useState(0);
@@ -41,9 +30,6 @@ export const File = memo(({ fileId, fileName, hasPermission }: FileProps) => {
 
   const handleClick = () => {
     setActiveFile(fileId);
-    appendLinear(activeTab.active, fileId, {
-      fileName: getFileName(fileId),
-    });
   };
 
   const handleActionClick = (type: DialogType) => {

--- a/apps/client/src/widgets/files/components/FileHeaderActions.tsx
+++ b/apps/client/src/widgets/files/components/FileHeaderActions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { Plus, Upload, Image } from 'lucide-react';
 import { Button } from '@codejam/ui';
 import { NewFileDialog } from '@/widgets/dialog/NewFileDialog';
@@ -6,8 +6,6 @@ import { DuplicateDialog } from '@/widgets/dialog/DuplicateDialog_new';
 import { ImageUploadDialog } from '@/widgets/dialog/ImageUploadDialog';
 import { useFileStore } from '@/stores/file';
 import { useFileRename } from '@/shared/lib/hooks/useFileRename';
-import { ActiveTabContext } from '@/contexts/TabProvider';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
 import { uploadFile } from '@/shared/lib/file';
 import { EXT_TYPES } from '@codejam/common';
 
@@ -17,10 +15,8 @@ const getAcceptedExtensions = () => {
 };
 
 export function FileHeaderActions({ roomCode }: { roomCode: string }) {
-  const { appendLinear } = useContext(LinearTabApiContext);
-  const { activeTab } = useContext(ActiveTabContext);
   const uploadRef = useRef<HTMLInputElement>(null);
-  const { getFileId, createFile, setActiveFile, getFileName } = useFileStore();
+  const { getFileId, createFile, setActiveFile } = useFileStore();
   const { handleCheckRename } = useFileRename(roomCode);
 
   const [isUrlDialogOpen, setIsUrlDialogOpen] = useState(false);
@@ -73,9 +69,6 @@ export function FileHeaderActions({ roomCode }: { roomCode: string }) {
       const result = await handleCheckRename(fullNames);
       if (result) {
         const fileId = createFile(fullNames, '');
-        appendLinear(activeTab.active, fileId, {
-          fileName: getFileName(fileId),
-        });
         setActiveFile(fileId);
       }
     }

--- a/apps/client/src/widgets/global-shortcuts/hooks/useFileOpen.ts
+++ b/apps/client/src/widgets/global-shortcuts/hooks/useFileOpen.ts
@@ -1,13 +1,8 @@
-import { useContext, useState } from 'react';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
-import { ActiveTabContext } from '@/contexts/TabProvider';
+import { useState } from 'react';
 import { useFileStore } from '@/stores/file';
 
 export function useFileOpen() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const { appendLinear } = useContext(LinearTabApiContext);
-  const { activeTab } = useContext(ActiveTabContext);
-  const getFileName = useFileStore((state) => state.getFileName);
   const setActiveFile = useFileStore((state) => state.setActiveFile);
 
   const handleOpenDialog = () => {
@@ -16,9 +11,6 @@ export function useFileOpen() {
 
   const handleSelectFile = (fileId: string) => {
     setActiveFile(fileId);
-    appendLinear(activeTab.active, fileId, {
-      fileName: getFileName(fileId),
-    });
   };
 
   return {

--- a/apps/client/src/widgets/header/ui/components/NewFileButton.tsx
+++ b/apps/client/src/widgets/header/ui/components/NewFileButton.tsx
@@ -9,20 +9,15 @@ import { DuplicateDialog } from '@/widgets/dialog/DuplicateDialog';
 import { useFileStore } from '@/stores/file';
 import { useFileRename } from '@/shared/lib/hooks/useFileRename';
 import { HeaderActionButton } from './HeaderActionButton';
-import { useContext } from 'react';
-import { LinearTabApiContext } from '@/contexts/ProviderAPI';
-import { ActiveTabContext } from '@/contexts/TabProvider';
 
 interface NewFileButtonProps {
   roomCode: string;
 }
 
 export function NewFileButton({ roomCode }: NewFileButtonProps) {
-  const { getFileId, createFile, setActiveFile, getFileName } = useFileStore();
+  const { getFileId, createFile, setActiveFile } = useFileStore();
   const { setIsDuplicated, isDuplicated, handleCheckRename } =
     useFileRename(roomCode);
-  const { appendLinear } = useContext(LinearTabApiContext);
-  const { activeTab } = useContext(ActiveTabContext);
   const handleNewFile = async (name: string) => {
     const newFilename = name;
     if (getFileId(newFilename)) {
@@ -31,9 +26,6 @@ export function NewFileButton({ roomCode }: NewFileButtonProps) {
       const result = await handleCheckRename(newFilename);
       if (result) {
         const fileId = createFile(newFilename, '');
-        appendLinear(activeTab.active, fileId, {
-          fileName: getFileName(fileId),
-        });
         setActiveFile(fileId);
       }
     }


### PR DESCRIPTION
…되도록 변경

<!-- PR 제목 형식: [FE/BE/COMMON/INFRA/DOC] 제목 (#이슈번호) -->

## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #N/A

## 🛠️ 작업 내용 (Description)

- FileObserver 컴포넌트를 통해 activeFileId 가 변경될 시 탭이 자동으로 생성
-

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [ ] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [ ] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

<!-- 리뷰 시 특별히 확인해야 할 부분이나 논의가 필요한 부분 -->
