### PR TITLE
[FE] Alt 키 OS별 표시 개선

### DIFF
--- a/apps/client/src/widgets/global-shortcuts/components/ShortcutListContent.tsx
+++ b/apps/client/src/widgets/global-shortcuts/components/ShortcutListContent.tsx
@@ -11,6 +11,7 @@ export function ShortcutListContent({ className }: ShortcutListContentProps) {
     typeof window !== 'undefined' &&
     /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
   const modKey = isMac ? '⌘' : 'Ctrl';
+  const altKey = isMac ? '⌥' : 'Alt';
 
   return (
     <div className={cn('flex flex-col gap-6', className)}>
@@ -24,7 +25,7 @@ export function ShortcutListContent({ className }: ShortcutListContentProps) {
         <ShortcutRow label="파일 열기" keys={[modKey, 'O']} />
         <ShortcutRow label="에디터 포커스" keys={[modKey, 'E']} />
         <ShortcutRow label="코드 실행" keys={[modKey, 'Shift', 'R']} />
-        <ShortcutRow label="탭 닫기" keys={['Alt', 'W']} />
+        <ShortcutRow label="탭 닫기" keys={[altKey, 'W']} />
         <ShortcutRow label="탭 탐색" keys={[modKey, '← / →']} />
         <ShortcutRow label="출력창 토글" keys={[modKey, 'J']} />
         <ShortcutRow label="출력창 토글 (대체)" keys={[modKey, '`']} />


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [x] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #

## 🛠️ 작업 내용 (Description)

- Mac에서는 'Option', Windows에서는 'Alt'로 표시되도록 개선
- 단축키 가이드의 일관성 향상

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음
- [ ] ## 있음 (아래에 기입)

## 📸 스크린샷 (Screenshots - Frontend Only)

<!-- UI 변경사항이 있다면 스크린샷을 첨부해주세요 -->

## ✅ 체크리스트 (Self Checklist)

- [ ] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [ ] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [ ] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

<!-- 리뷰 시 특별히 확인해야 할 부분이나 논의가 필요한 부분 -->
