### PR TITLE
[BE] Socket.io 소켓 고유 ID를 Throttler 키로 사용하도록 수정

### DIFF
--- a/apps/server/src/common/guards/ws-throttler.guard.ts
+++ b/apps/server/src/common/guards/ws-throttler.guard.ts
@@ -5,13 +5,23 @@ import { WsApiException } from '../exceptions/ws-api.exception';
 
 @Injectable()
 export class WsThrottlerGuard extends ThrottlerGuard {
+  protected generateKey(
+    context: ExecutionContext,
+    suffix: string,
+    name: string,
+  ): string {
+    const client = context.switchToWs().getClient();
+    return `${suffix}-${name}-${client.id}`;
+  }
+
   protected getRequestResponse(context: ExecutionContext) {
     const wsCtx = context.switchToWs();
     const client = wsCtx.getClient();
 
     return {
       req: {
-        ip: client.conn.remoteAddress,
+        // 내부 로직용 객체 구조 유지
+        ip: client.id,
         headers: client.handshake.headers,
       },
       res: client,


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [ ] **Frontend** (React)
- [x] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [ ] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- Issue Number: #339

## 🛠️ 작업 내용 (Description)

- Socket.io의 소켓 고유 ID를 Throttler 키로 사용하도록 수정했습니다.
- suffix와 name을 포함하여 Throttler 설정별 고유성을 보장합니다.

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [x] (필요 시) 테스트 코드를 작성하거나 통과했나요?
