### PR TITLE
[INFRA] Caddyfile(ZeroSSL) 및 docker-compose(Caddy 볼륨) 복원 

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -177,7 +177,7 @@ jobs:
               --restart unless-stopped \
               --network codejam_codejam-net \
               -p 3001:3000 \
-              -p 9091:9091 \
+              -p 9092:9091 \
               --env-file /home/ubuntu/.env.staging \
               ${{ secrets.OCIR_REGION_KEY }}.ocir.io/${{ secrets.OCIR_NAMESPACE }}/${{ secrets.OCIR_REPOSITORY }}:staging-${{ github.sha }}
             sudo docker image prune -af

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,7 +1,7 @@
 {
     # Let's Encrypt (프론트는 Vercel www.codejam.app, API만 이 서버에서 처리)
     email {env.ACME_EMAIL}
-    acme_ca https://acme-v02.api.letsencrypt.org/directory
+    acme_ca https://acme.zerossl.com/v2/DV90
 }
 
 # 프로덕션 API → server-prod (DNS: api.codejam.app A → Oracle VM)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,14 @@
-# Oracle VM 수동 배포용 통합 compose (프로덕션/스테이징·DB·Redis·Piston·Caddy 등).
-# 이미지는 호스트 빌드 산출물을 COPY하는 apps/server/Dockerfile 기준 — CI 레지스트리 빌드와는 별 트랙으로 두었음.
+# ==============================================================================
+# [주의] 수동 실행 및 로컬 개발 전용 (MANUAL USE ONLY) (오라클 서버 수동 배포에 사용되었습니다)
+# ------------------------------------------------------------------------------
+# 1. 이 파일은 GitHub Actions 자동 배포(OCIR) 파이프라인에 사용되지 않습니다.
+# 2. 서버 배포는 cd-*.yml 워크플로우를 통해 'docker run' 방식으로 직접 수행됩니다.
+# 3. 로컬 테스트나 서버에서 수동으로 컨테이너를 올릴 때만 수정/사용하세요.
+# ==============================================================================
 
 services:
   server-prod:
+    # 수동 배포 기본 이미지 태그(호스트에서 compose up 시 사용)
     image: codejam-server:production
     build:
       context: .
@@ -36,6 +42,7 @@ services:
       - codejam-net
 
   server-staging:
+    # 수동 배포 기본 이미지 태그(호스트에서 compose up 시 사용)
     image: codejam-server:staging
     build:
       context: .
@@ -130,7 +137,8 @@ services:
       - '443:443'
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
-      - caddy_data:/root/.local/share/caddy
+      - caddy_data:/data
+      - caddy_config:/config
     command: ['caddy', 'run', '--config', '/etc/caddy/Caddyfile']
     depends_on:
       - server-prod
@@ -144,6 +152,8 @@ services:
 
 volumes:
   caddy_data:
+    driver: local
+  caddy_config:
     driver: local
   redis_data:
     driver: local


### PR DESCRIPTION
## 📋 작업 범위 (Scope)

- [ ] **Frontend** (React)
- [ ] **Backend** (NestJS)
- [ ] **Common** (Shared Types, Utils)
- [x] **Infrastructure** (DevOps, CI/CD, Docker)
- [ ] **Documentation** (README, Wiki)

## 🔗 관련 이슈 (Related Issue)

- 관련 PR: #374 (원본), #375 (revert), #376 (워크플로우 복원)

## 🛠️ 작업 내용 (Description)

- #375 revert로 인해 되돌아간 나머지 인프라 파일 2개를 복원합니다.
- `Caddyfile`: Let's Encrypt 인증서 발급 제한(rate limit)으로 전환했던 **ZeroSSL** ACME CA 설정 복원
- `docker-compose.yml`: Caddy 인증서 영속화를 위한 **볼륨 마운트(`/data`, `/config`)** 및 수동 배포 관련 주석 복원

### 경위
- #374 머지 전 dev ← main 충돌 해결 과정에서 일부 설정이 NCP/옛날 버전으로 섞임
- #375 긴급 revert → 전체 인프라 설정이 옛날로 복귀
- #376 에서 워크플로우/Dockerfile/env 5개 파일 복원 완료
- **이번 PR로 Caddyfile + docker-compose.yml 복원하여 전체 정상화 완료**

## 📦 패키지 변경 사항 (Dependencies)

- [x] 없음

## ✅ 체크리스트 (Self Checklist)

- [x] 코드가 정상적으로 빌드/실행되는지 확인했나요?
- [x] 관련된 변경 사항(DB 스키마, 환경변수 등)을 팀원에게 공지했나요?
- [x] 불필요한 로그(console.log)나 주석을 제거했나요?
- [ ] (필요 시) 테스트 코드를 작성하거나 통과했나요?

## 💬 추가 논의사항 (Optional)

- 이 PR 머지 후 dev에도 `git merge origin/main`으로 동기화가 필요합니다.
- 이 PR로 #375 revert 피해 복원이 **전부 완료**됩니다.